### PR TITLE
docs: add contributor guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,3 +651,5 @@ cp env.example .env
 ---
 
 **OpenCare-Africa** - Empowering healthcare in Africa through technology.
+## Contributing
+## Please read our contributor guide before making changes.


### PR DESCRIPTION
This PR ads a contributing section to the README.
Fixes the issue of missing contributor guidelines.
Related to issue: #1 
This change helps new developers understand how to contribute