### PR TITLE
docs: add project architecture and folder overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,3 +651,9 @@ cp env.example .env
 ---
 
 **OpenCare-Africa** - Empowering healthcare in Africa through technology.
+
+## Project Structure
+- `/src`: Contains the primary source code.
+- `/public`: Static assets and public resources.
+- `/docs`: Additional project documentation.
+- `/tests`: Unit and integration tests.


### PR DESCRIPTION
Added a "Project Structure" section to the documentation. This helps new contributors understand the relationship between the /src, /public, and /docs directories for better navigation.

Closes #1