### PR TITLE
docs: add env.example with required environment variables

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,53 +1,50 @@
 # Django Configuration
 SECRET_KEY=your-secret-key-here
 DEBUG=True
-ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
+ALLOWED_HOSTS=localhost,127.0.0.1
 
 # Database Configuration
 DB_ENGINE=django.db.backends.postgresql
 DB_NAME=opencare_africa
 DB_USER=opencare_user
 DB_PASSWORD=opencare_password
-DB_HOST=localhost
+DB_HOST=db
 DB_PORT=5432
 
 # Redis Configuration
-REDIS_HOST=localhost
+REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_DB=0
-
-# Celery Configuration
-CELERY_BROKER_URL=redis://localhost:6379/0
-CELERY_RESULT_BACKEND=redis://localhost:6379/0
 
 # JWT Configuration
 JWT_ACCESS_TOKEN_LIFETIME=5
 JWT_REFRESH_TOKEN_LIFETIME=1
 
-# CORS Configuration
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
+# Celery Configuration
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0
 
 # Email Configuration
 EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
-EMAIL_HOST=localhost
+EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587
 EMAIL_USE_TLS=True
-EMAIL_HOST_USER=
-EMAIL_HOST_PASSWORD=
+EMAIL_HOST_USER=your-email@example.com
+EMAIL_HOST_PASSWORD=your-email-password
 
-# Internationalization
-LANGUAGE_CODE=en-us
-TIME_ZONE=UTC
-USE_I18N=True
-USE_L10N=True
-USE_TZ=True
+# Sentry (Production)
+SENTRY_DSN=your-sentry-dsn-here
+```
 
-# Static and Media Files
-STATIC_URL=/static/
-STATIC_ROOT=staticfiles
-MEDIA_URL=/media/
-MEDIA_ROOT=media
+---
 
-# Development Tools
-USE_DEBUG_TOOLBAR=True
-USE_SILK_PROFILER=False
+## How to Create It on GitHub
+
+1. Make sure you're on the `docs/add-env-example-file` branch
+2. Click **"Add file"** → **"Create new file"**
+3. Type `env.example` as the file name
+4. Paste the content above
+5. Scroll down to **"Commit changes"**
+6. Write the commit message:
+```
+   docs: add env.example with all required environment variables


### PR DESCRIPTION
Added env.example template at the root of the repository with all required variables for Django, PostgreSQL, Redis, JWT, Celery, Email, and Sentry.

Closes #<51>