### PR TITLE
docs: improve installation instructions and add contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,3 +651,7 @@ cp env.example .env
 ---
 
 **OpenCare-Africa** - Empowering healthcare in Africa through technology.
+
+
+## Contributing
+Please read the [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.


### PR DESCRIPTION
This PR resolves the documentation gap by adding a standard `CONTRIBUTING.md` and updating the README.
This change is extremely useful for onboarding new developers to the OpenCare-Core project.