### PR TITLE
Dave opencare corefeat(appointments): Implement Appointment Scheduling API for Patient-Health Worker Bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ docker run -e DJANGO_SETTINGS_MODULE=config.settings.production opencare-africa:
 - **Code Documentation**: Comprehensive docstrings
 - **Admin Interface**: Django admin for data management
 - **User Guides**: Available in `/docs/` directory
+- **Patient Records**: See [`docs/patient-records.md`](docs/patient-records.md) for CRUD usage and security notes
 - **Audit Logging**: See [`docs/audit-logs.md`](docs/audit-logs.md) for PHI access tracking requirements
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ The API is fully documented using OpenAPI/Swagger:
 - **Facilities**: `/api/v1/facilities/`
 - **Health Records**: `/api/v1/records/`
 - **Analytics**: `/api/v1/analytics/`
+- **Appointments**: `/api/v1/appointments/`
 
 ## 🗄️ Database Schema
 
@@ -389,6 +390,7 @@ docker run -e DJANGO_SETTINGS_MODULE=config.settings.production opencare-africa:
 - **User Guides**: Available in `/docs/` directory
 - **Patient Records**: See [`docs/patient-records.md`](docs/patient-records.md) for CRUD usage and security notes
 - **Audit Logging**: See [`docs/audit-logs.md`](docs/audit-logs.md) for PHI access tracking requirements
+- **Appointments**: See [`docs/appointments.md`](docs/appointments.md) for scheduling API usage and safeguards
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ The API is fully documented using OpenAPI/Swagger:
 - **Facilities**: `/api/v1/facilities/`
 - **Health Records**: `/api/v1/records/`
 - **Analytics**: `/api/v1/analytics/`
+- **Appointments**: `/api/v1/appointments/`
 
 ## 🗄️ Database Schema
 
@@ -388,6 +389,7 @@ docker run -e DJANGO_SETTINGS_MODULE=config.settings.production opencare-africa:
 - **Admin Interface**: Django admin for data management
 - **User Guides**: Available in `/docs/` directory
 - **Audit Logging**: See [`docs/audit-logs.md`](docs/audit-logs.md) for PHI access tracking requirements
+- **Appointments**: See [`docs/appointments.md`](docs/appointments.md) for scheduling API usage and safeguards
 
 ## 🤝 Contributing
 

--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -1,0 +1,42 @@
+"""
+Custom permission classes for API access control.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from rest_framework.permissions import BasePermission
+
+
+class IsClinicalStaff(BasePermission):
+    """
+    Allow requests from authenticated clinical staff or superusers.
+
+    Clinical staff is defined as any user whose `user_type` is in
+    `CLINICAL_ROLES`. Read and write operations are blocked for other roles,
+    ensuring sensitive health records are only modified by qualified users.
+    """
+
+    CLINICAL_ROLES: Iterable[str] = (
+        "doctor",
+        "nurse",
+        "midwife",
+        "pharmacist",
+        "lab_technician",
+    )
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        if user.is_superuser:
+            return True
+        return getattr(user, "user_type", None) in self.CLINICAL_ROLES
+
+    def has_object_permission(self, request, view, obj) -> bool:  # noqa: D401
+        """
+        Mirror `has_permission` so object-level checks follow the same rule.
+        """
+
+        return self.has_permission(request, view)

--- a/apps/api/permissions.py
+++ b/apps/api/permissions.py
@@ -4,9 +4,21 @@ Custom permission classes for API access control.
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Set
 
+from django.utils.translation import gettext_lazy as _
 from rest_framework.permissions import BasePermission
+
+
+def _normalize_roles(roles: Iterable[str]) -> frozenset[str]:
+    """Normalize role values to strings."""
+    normalized: Set[str] = set()
+    for role in roles:
+        if hasattr(role, "value"):
+            normalized.add(str(role.value))
+        else:
+            normalized.add(str(role))
+    return frozenset(normalized)
 
 
 class IsClinicalStaff(BasePermission):
@@ -38,5 +50,41 @@ class IsClinicalStaff(BasePermission):
         """
         Mirror `has_permission` so object-level checks follow the same rule.
         """
-
         return self.has_permission(request, view)
+
+
+class RoleRequired(BasePermission):
+    """DRF permission enforcing role membership based on ``view.required_roles``."""
+
+    message = _("You do not have permission to perform this action.")
+
+    def has_permission(self, request, view) -> bool:  # type: ignore[override]
+        required = getattr(view, "required_roles", None)
+        if required is None and hasattr(view, "cls"):
+            required = getattr(view.cls, "required_roles", None)
+
+        if not required:
+            return True
+
+        user = getattr(request, "user", None)
+        if user is None or not getattr(user, "is_authenticated", False):
+            return False
+
+        if getattr(user, "is_admin_role", False) or getattr(user, "is_superuser", False):
+            return True
+
+        return getattr(user, "role", None) in required
+
+
+def require_roles(*roles: str):
+    """Decorator to attach required roles metadata to API views."""
+
+    normalized = _normalize_roles(roles)
+
+    def decorator(view):
+        setattr(view, "required_roles", normalized)
+        if hasattr(view, "cls"):
+            setattr(view.cls, "required_roles", normalized)
+        return view
+
+    return decorator

--- a/apps/api/tests/test_health_records_api.py
+++ b/apps/api/tests/test_health_records_api.py
@@ -1,0 +1,199 @@
+"""
+API tests validating patient health record CRUD flows.
+"""
+
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.core.models import HealthFacility, Location
+from apps.patients.models import Patient
+from apps.records.models import HealthRecord
+
+
+User = get_user_model()
+
+
+class HealthRecordAPITests(APITestCase):
+    """
+    Exercise the records endpoint to ensure role enforcement and functionality.
+    """
+
+    def setUp(self):
+        """
+        Create reusable fixtures for each test case.
+        """
+
+        self.clinical_user = User.objects.create_user(
+            username="doctor1",
+            password="testpass123",
+            user_type="doctor",
+            first_name="Dana",
+            last_name="Doctor",
+        )
+        self.non_clinical_user = User.objects.create_user(
+            username="community1",
+            password="testpass123",
+            user_type="community_worker",
+            first_name="Case",
+            last_name="Worker",
+        )
+        self.location = Location.objects.create(
+            name="Central Region",
+            location_type="region",
+        )
+        self.facility = HealthFacility.objects.create(
+            name="Central Hospital",
+            facility_type="hospital",
+            location=self.location,
+            address="123 Main Street",
+            phone_number="+256700000000",
+            email="central@example.com",
+            website="",
+            is_24_hours=True,
+            contact_person_name="Head Nurse",
+            contact_person_phone="+256700000001",
+            services_offered=[],
+        )
+        self.patient = Patient.objects.create(
+            patient_id="PAT-2001",
+            first_name="Jane",
+            last_name="Doe",
+            date_of_birth=timezone.now().date() - timedelta(days=30 * 365),
+            gender="F",
+            phone_number="+256700000002",
+            email="jane@example.com",
+            address="456 Care Road",
+            location=self.location,
+            emergency_contact_name="John Doe",
+            emergency_contact_phone="+256700000003",
+            emergency_contact_relationship="Sibling",
+            registered_facility=self.facility,
+        )
+        self.list_url = reverse("api:records-list")
+        self.client.force_authenticate(self.clinical_user)
+
+    def _payload(self, **overrides):
+        """
+        Build a base payload for record creation, overriding as needed.
+        """
+
+        base = {
+            "patient": self.patient.pk,
+            "facility": self.facility.pk,
+            "record_type": "medical",
+            "record_date": timezone.now().isoformat(),
+            "attending_provider": self.clinical_user.pk,
+            "chief_complaint": "Mild headache",
+            "assessment": "Observation required",
+            "diagnosis": [],
+            "treatment_plan": "Monitor symptoms",
+            "follow_up_plan": "Return in one week",
+            "notes": "Initial consultation",
+            "is_confidential": False,
+            "is_active": True,
+        }
+        base.update(overrides)
+        return base
+
+    def test_clinical_staff_can_create_record(self):
+        """
+        Clinical roles should be able to create patient records.
+        """
+
+        response = self.client.post(self.list_url, data=self._payload(), format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(HealthRecord.objects.count(), 1)
+
+    def test_non_clinical_user_forbidden(self):
+        """
+        Non-clinical roles must be denied read access.
+        """
+
+        self.client.force_authenticate(self.non_clinical_user)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_record(self):
+        """
+        Ensure updates persist and return the latest content.
+        """
+
+        record = HealthRecord.objects.create(
+            patient=self.patient,
+            facility=self.facility,
+            record_type="medical",
+            record_date=timezone.now(),
+            attending_provider=self.clinical_user,
+        )
+        url = reverse("api:records-detail", args=[record.pk])
+        response = self.client.patch(
+            url,
+            data={"assessment": "Condition improving"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        record.refresh_from_db()
+        self.assertEqual(record.assessment, "Condition improving")
+
+    def test_delete_record(self):
+        """
+        Deleting a record should remove it from the database.
+        """
+
+        record = HealthRecord.objects.create(
+            patient=self.patient,
+            facility=self.facility,
+            record_type="medical",
+            record_date=timezone.now(),
+            attending_provider=self.clinical_user,
+        )
+        url = reverse("api:records-detail", args=[record.pk])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(HealthRecord.objects.filter(pk=record.pk).exists())
+
+    def test_filter_by_record_type(self):
+        """
+        Verify that filter parameters narrow the result set.
+        """
+
+        HealthRecord.objects.create(
+            patient=self.patient,
+            facility=self.facility,
+            record_type="medical",
+            record_date=timezone.now(),
+            attending_provider=self.clinical_user,
+        )
+        HealthRecord.objects.create(
+            patient=self.patient,
+            facility=self.facility,
+            record_type="imaging",
+            record_date=timezone.now(),
+            attending_provider=self.clinical_user,
+        )
+        response = self.client.get(self.list_url, {"record_type": "imaging"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["record_type"], "imaging")
+
+    def test_by_patient_action(self):
+        """
+        The by-patient helper should return records scoped by external ID.
+        """
+
+        HealthRecord.objects.create(
+            patient=self.patient,
+            facility=self.facility,
+            record_type="medical",
+            record_date=timezone.now(),
+            attending_provider=self.clinical_user,
+        )
+        url = reverse("api:records-by-patient")
+        response = self.client.get(url, {"patient_id": self.patient.patient_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)

--- a/apps/api/tests/test_rbac.py
+++ b/apps/api/tests/test_rbac.py
@@ -1,0 +1,131 @@
+"""
+RBAC enforcement tests for API endpoints.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient, APIRequestFactory
+
+from apps.api.permissions import RoleRequired
+
+User = get_user_model()
+
+
+class RBACPermissionTests(TestCase):
+    """Validate role-based access control wiring."""
+
+    def setUp(self) -> None:
+        self.factory = APIRequestFactory()
+
+        self.admin_user = User.objects.create_user(
+            username="rbac-admin",
+            password="testpass123",
+            email="admin@example.com",
+            role=User.Role.ADMIN,
+            is_staff=True,
+            is_superuser=True,
+        )
+
+        self.provider_user = User.objects.create_user(
+            username="rbac-provider",
+            password="testpass123",
+            email="provider@example.com",
+            role=User.Role.PROVIDER,
+        )
+
+        self.patient_user = User.objects.create_user(
+            username="rbac-patient",
+            password="testpass123",
+            email="patient@example.com",
+            role=User.Role.PATIENT,
+        )
+
+    def _client_for(self, user: User) -> APIClient:
+        client = APIClient()
+        client.force_authenticate(user)
+        return client
+
+    def test_patient_blocked_from_clinical_endpoints(self):
+        """Patients should receive 403 when calling staff-only endpoints."""
+        client = self._client_for(self.patient_user)
+        url = reverse("api:patients-list")
+        response = client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_provider_blocked_from_admin_only_metrics(self):
+        """Providers must not access admin-only statistics endpoints."""
+        client = self._client_for(self.provider_user)
+        url = reverse("api:api_stats")
+        response = client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_can_access_admin_only_endpoints(self):
+        """Admins should be able to call restricted endpoints."""
+        client = self._client_for(self.admin_user)
+        stats_url = reverse("api:api_stats")
+        export_url = reverse("api:export_data")
+
+        stats_response = client.get(stats_url)
+        self.assertEqual(stats_response.status_code, 200)
+
+        export_response = client.post(export_url, {"format": "csv", "type": "patients"}, format="json")
+        self.assertEqual(export_response.status_code, 200)
+        self.assertEqual(export_response.data["format"], "csv")
+
+    def test_role_required_allows_provider_role(self):
+        """RoleRequired should allow users whose role matches the requirement."""
+        permission = RoleRequired()
+
+        class DummyView:
+            required_roles = frozenset({User.Role.PROVIDER})
+
+        request = self.factory.get("/dummy")
+        request.user = self.provider_user
+
+        self.assertTrue(permission.has_permission(request, DummyView()))
+
+        request.user = self.patient_user
+        self.assertFalse(permission.has_permission(request, DummyView()))
+
+        request.user = self.admin_user
+        self.assertTrue(permission.has_permission(request, DummyView()))
+
+    def test_provider_can_access_provider_endpoints(self):
+        """Providers should access endpoints allowed for providers."""
+        client = self._client_for(self.provider_user)
+        url = reverse("api:patients-list")
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_admin_can_access_all_endpoints(self):
+        """Admins should have access to all endpoints."""
+        client = self._client_for(self.admin_user)
+        
+        # Test provider endpoints
+        patients_url = reverse("api:patients-list")
+        response = client.get(patients_url)
+        self.assertEqual(response.status_code, 200)
+        
+        # Test admin-only endpoints
+        health_workers_url = reverse("api:health-workers-list")
+        response = client.get(health_workers_url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_unauthenticated_blocked(self):
+        """Unauthenticated users should be blocked from protected endpoints."""
+        client = APIClient()
+        url = reverse("api:patients-list")
+        response = client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_health_check_public(self):
+        """Health check endpoint should be publicly accessible."""
+        client = APIClient()
+        url = reverse("api:health_check")
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["status"], "healthy")
+

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -11,13 +11,12 @@ app_name = 'api'
 
 # Create a router and register our viewsets with it
 router = DefaultRouter()
-# Combined content from both branches:
 router.register(r'patients', views.PatientViewSet, basename='patients')
 router.register(r'health-workers', views.HealthWorkerViewSet, basename='health-workers')
 router.register(r'facilities', views.FacilityViewSet, basename='facilities')
 router.register(r'visits', views.PatientVisitViewSet, basename='visits')
 router.register(r'records', views.HealthRecordViewSet, basename='records')
-router.register(r'audit-logs', views.AuditTrailViewSet, basename='audit-logs') # The new registration
+router.register(r'audit-logs', views.AuditTrailViewSet, basename='audit-logs')
 
 urlpatterns = [
     # API v1 endpoints

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -17,6 +17,7 @@ router.register(r'facilities', views.FacilityViewSet, basename='facilities')
 router.register(r'visits', views.PatientVisitViewSet, basename='visits')
 router.register(r'records', views.HealthRecordViewSet, basename='records')
 router.register(r'audit-logs', views.AuditTrailViewSet, basename='audit-logs')
+router.register(r'appointments', views.AppointmentViewSet, basename='appointment')
 
 urlpatterns = [
     # API v1 endpoints

--- a/apps/api/urls.py
+++ b/apps/api/urls.py
@@ -17,6 +17,7 @@ router.register(r'facilities', views.FacilityViewSet)
 router.register(r'visits', views.PatientVisitViewSet)
 router.register(r'records', views.HealthRecordViewSet)
 router.register(r'audit-logs', views.AuditTrailViewSet, basename='audit-logs')
+router.register(r'appointments', views.AppointmentViewSet, basename='appointment')
 
 urlpatterns = [
     # API v1 endpoints

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -12,6 +12,7 @@ from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
 from apps.api.mixins import AuditLogMixin
+from apps.appointments.views import AppointmentViewSet  # re-export for router
 from apps.core.models import AuditTrail, HealthFacility
 from apps.core.serializers import (
     AuditTrailSerializer,

--- a/apps/appointments/admin.py
+++ b/apps/appointments/admin.py
@@ -1,0 +1,44 @@
+"""
+Admin configuration for appointments.
+"""
+
+from django.contrib import admin
+
+from .models import Appointment
+
+
+@admin.register(Appointment)
+class AppointmentAdmin(admin.ModelAdmin):
+    """
+    Read-only admin for viewing appointments.
+    """
+
+    list_display = [
+        "patient",
+        "provider",
+        "facility",
+        "start_time",
+        "end_time",
+        "status",
+    ]
+    list_filter = ["status", "facility", "provider"]
+    search_fields = [
+        "patient__first_name",
+        "patient__last_name",
+        "provider__first_name",
+        "provider__last_name",
+        "facility__name",
+    ]
+    ordering = ["-start_time"]
+    readonly_fields = [
+        "created_at",
+        "updated_at",
+        "notifications_sent",
+        "created_by",
+    ]
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False

--- a/apps/appointments/apps.py
+++ b/apps/appointments/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class AppointmentsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.appointments"
+    verbose_name = "Appointments"

--- a/apps/appointments/models.py
+++ b/apps/appointments/models.py
@@ -1,0 +1,68 @@
+"""
+Appointment scheduling models.
+"""
+
+from django.conf import settings
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class Appointment(models.Model):
+    """
+    Represents a scheduled interaction between a patient and provider.
+    """
+
+    class Status(models.TextChoices):
+        SCHEDULED = "scheduled", _("Scheduled")
+        COMPLETED = "completed", _("Completed")
+        CANCELLED = "cancelled", _("Cancelled")
+        NO_SHOW = "no_show", _("No Show")
+
+    patient = models.ForeignKey(
+        "patients.Patient",
+        on_delete=models.CASCADE,
+        related_name="appointments",
+    )
+    provider = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="appointments",
+    )
+    facility = models.ForeignKey(
+        "core.HealthFacility",
+        on_delete=models.CASCADE,
+        related_name="appointments",
+    )
+    appointment_type = models.CharField(max_length=50, blank=True)
+    reason = models.TextField(blank=True)
+    status = models.CharField(
+        max_length=20,
+        choices=Status.choices,
+        default=Status.SCHEDULED,
+    )
+    start_time = models.DateTimeField()
+    end_time = models.DateTimeField()
+    notifications_sent = models.JSONField(default=list, blank=True)
+
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        related_name="appointments_created",
+        null=True,
+        blank=True,
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = _("Appointment")
+        verbose_name_plural = _("Appointments")
+        ordering = ["start_time"]
+        indexes = [
+            models.Index(fields=["provider", "start_time"]),
+            models.Index(fields=["patient", "start_time"]),
+            models.Index(fields=["facility", "start_time"]),
+        ]
+
+    def __str__(self):
+        return f"{self.patient} with {self.provider} on {self.start_time:%Y-%m-%d %H:%M}"

--- a/apps/appointments/notifications.py
+++ b/apps/appointments/notifications.py
@@ -1,23 +1,196 @@
 """
-Notification hooks for appointment events.
+Notification hooks for appointment events with email/SMS support.
 """
 
 import logging
-from typing import Literal
+from typing import Literal, Optional
+from django.conf import settings
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+from django.utils import timezone
 
 from .models import Appointment
 
 logger = logging.getLogger(__name__)
 
-AppointmentEvent = Literal["created", "updated", "cancelled"]
+AppointmentEvent = Literal["created", "updated", "cancelled", "reminder"]
+
+
+def send_email_notification(
+    appointment: Appointment,
+    event: AppointmentEvent,
+    recipient_email: str,
+    recipient_name: str
+) -> bool:
+    """
+    Send email notification for appointment events.
+    
+    Returns True if email was sent successfully, False otherwise.
+    """
+    try:
+        subject = _get_email_subject(appointment, event)
+        message = _get_email_message(appointment, event, recipient_name)
+        from_email = getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@opencare-africa.com")
+        
+        send_mail(
+            subject=subject,
+            message=message,
+            from_email=from_email,
+            recipient_list=[recipient_email],
+            fail_silently=False,
+        )
+        logger.info(f"Email sent to {recipient_email} for appointment {appointment.id} event {event}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to send email to {recipient_email}: {str(e)}")
+        return False
+
+
+def send_sms_notification(
+    appointment: Appointment,
+    event: AppointmentEvent,
+    recipient_phone: str,
+    recipient_name: str
+) -> bool:
+    """
+    Send SMS notification for appointment events.
+    
+    This is a hook for SMS providers. In production, integrate with:
+    - Twilio
+    - AWS SNS
+    - Africa's Talking
+    - Other SMS gateway services
+    
+    Returns True if SMS was sent successfully, False otherwise.
+    """
+    try:
+        message = _get_sms_message(appointment, event, recipient_name)
+        
+        # TODO: Integrate with actual SMS provider
+        # Example with Twilio:
+        # from twilio.rest import Client
+        # client = Client(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
+        # client.messages.create(
+        #     body=message,
+        #     from_=settings.TWILIO_PHONE_NUMBER,
+        #     to=recipient_phone
+        # )
+        
+        # For now, log the SMS that would be sent
+        logger.info(f"SMS would be sent to {recipient_phone}: {message}")
+        logger.info(f"SMS notification for appointment {appointment.id} event {event}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to send SMS to {recipient_phone}: {str(e)}")
+        return False
+
+
+def _get_email_subject(appointment: Appointment, event: AppointmentEvent) -> str:
+    """Generate email subject based on event type."""
+    subjects = {
+        "created": f"Appointment Scheduled - {appointment.start_time.strftime('%B %d, %Y at %I:%M %p')}",
+        "updated": f"Appointment Updated - {appointment.start_time.strftime('%B %d, %Y at %I:%M %p')}",
+        "cancelled": f"Appointment Cancelled - {appointment.start_time.strftime('%B %d, %Y at %I:%M %p')}",
+        "reminder": f"Appointment Reminder - {appointment.start_time.strftime('%B %d, %Y at %I:%M %p')}",
+    }
+    return subjects.get(event, "Appointment Notification")
+
+
+def _get_email_message(appointment: Appointment, event: AppointmentEvent, recipient_name: str) -> str:
+    """Generate email message body."""
+    provider_name = appointment.provider.get_full_name()
+    patient_name = appointment.patient.get_full_name()
+    facility_name = appointment.facility.name
+    
+    messages = {
+        "created": f"""
+Hello {recipient_name},
+
+Your appointment has been scheduled:
+
+Patient: {patient_name}
+Provider: {provider_name}
+Facility: {facility_name}
+Date & Time: {appointment.start_time.strftime('%B %d, %Y at %I:%M %p')}
+Duration: {appointment.duration_minutes} minutes
+Type: {appointment.appointment_type or 'General Consultation'}
+Reason: {appointment.reason or 'Not specified'}
+
+Please arrive 10 minutes before your scheduled time.
+
+Thank you,
+OpenCare-Africa Team
+        """,
+        "updated": f"""
+Hello {recipient_name},
+
+Your appointment has been updated:
+
+Patient: {patient_name}
+Provider: {provider_name}
+Facility: {facility_name}
+New Date & Time: {appointment.start_time.strftime('%B %d, %Y at %I:%M %p')}
+Duration: {appointment.duration_minutes} minutes
+
+Please note the new time and arrive 10 minutes early.
+
+Thank you,
+OpenCare-Africa Team
+        """,
+        "cancelled": f"""
+Hello {recipient_name},
+
+Your appointment has been cancelled:
+
+Patient: {patient_name}
+Provider: {provider_name}
+Facility: {facility_name}
+Original Date & Time: {appointment.start_time.strftime('%B %d, %Y at %I:%M %p')}
+
+If you need to reschedule, please contact the facility or book a new appointment.
+
+Thank you,
+OpenCare-Africa Team
+        """,
+        "reminder": f"""
+Hello {recipient_name},
+
+This is a reminder about your upcoming appointment:
+
+Patient: {patient_name}
+Provider: {provider_name}
+Facility: {facility_name}
+Date & Time: {appointment.start_time.strftime('%B %d, %Y at %I:%M %p')}
+Duration: {appointment.duration_minutes} minutes
+
+Please arrive 10 minutes before your scheduled time.
+
+Thank you,
+OpenCare-Africa Team
+        """,
+    }
+    return messages.get(event, "Appointment notification").strip()
+
+
+def _get_sms_message(appointment: Appointment, event: AppointmentEvent, recipient_name: str) -> str:
+    """Generate SMS message body (shorter than email)."""
+    provider_name = appointment.provider.get_full_name()
+    date_str = appointment.start_time.strftime('%b %d, %Y at %I:%M %p')
+    
+    messages = {
+        "created": f"Appointment scheduled: {date_str} with {provider_name} at {appointment.facility.name}. Arrive 10 mins early.",
+        "updated": f"Appointment updated: {date_str} with {provider_name} at {appointment.facility.name}.",
+        "cancelled": f"Appointment cancelled: {date_str} with {provider_name}. Contact facility to reschedule.",
+        "reminder": f"Reminder: Appointment tomorrow {date_str} with {provider_name} at {appointment.facility.name}.",
+    }
+    return messages.get(event, "Appointment notification")
 
 
 def send_notification(appointment: Appointment, event: AppointmentEvent) -> None:
     """
-    Dispatch notifications for appointment changes.
-
-    In production this should integrate with email/SMS providers. For now we
-    log the event so downstream systems can subscribe.
+    Dispatch notifications for appointment changes via email and SMS.
+    
+    Sends notifications to both patient and provider when appropriate.
     """
     logger.info(
         "Appointment %s: patient=%s provider=%s start=%s status=%s",
@@ -27,6 +200,48 @@ def send_notification(appointment: Appointment, event: AppointmentEvent) -> None
         appointment.start_time.isoformat(),
         appointment.status,
     )
-    notifications = list(appointment.notifications_sent or [])
-    notifications.append(event)
-    Appointment.objects.filter(pk=appointment.pk).update(notifications_sent=notifications)
+    
+    notifications_sent = []
+    
+    # Send to patient
+    if appointment.patient.email:
+        email_sent = send_email_notification(
+            appointment, event,
+            appointment.patient.email,
+            appointment.patient.get_full_name()
+        )
+        if email_sent:
+            notifications_sent.append({"type": "email", "recipient": "patient", "method": "email", "sent_at": timezone.now().isoformat()})
+    
+    if appointment.patient.phone_number:
+        sms_sent = send_sms_notification(
+            appointment, event,
+            appointment.patient.phone_number,
+            appointment.patient.get_full_name()
+        )
+        if sms_sent:
+            notifications_sent.append({"type": "sms", "recipient": "patient", "method": "sms", "sent_at": timezone.now().isoformat()})
+    
+    # Send to provider
+    if appointment.provider.email:
+        email_sent = send_email_notification(
+            appointment, event,
+            appointment.provider.email,
+            appointment.provider.get_full_name()
+        )
+        if email_sent:
+            notifications_sent.append({"type": "email", "recipient": "provider", "method": "email", "sent_at": timezone.now().isoformat()})
+    
+    if appointment.provider.phone_number:
+        sms_sent = send_sms_notification(
+            appointment, event,
+            appointment.provider.phone_number,
+            appointment.provider.get_full_name()
+        )
+        if sms_sent:
+            notifications_sent.append({"type": "sms", "recipient": "provider", "method": "sms", "sent_at": timezone.now().isoformat()})
+    
+    # Update appointment with notification history
+    existing_notifications = list(appointment.notifications_sent or [])
+    existing_notifications.extend(notifications_sent)
+    Appointment.objects.filter(pk=appointment.pk).update(notifications_sent=existing_notifications)

--- a/apps/appointments/notifications.py
+++ b/apps/appointments/notifications.py
@@ -1,0 +1,32 @@
+"""
+Notification hooks for appointment events.
+"""
+
+import logging
+from typing import Literal
+
+from .models import Appointment
+
+logger = logging.getLogger(__name__)
+
+AppointmentEvent = Literal["created", "updated", "cancelled"]
+
+
+def send_notification(appointment: Appointment, event: AppointmentEvent) -> None:
+    """
+    Dispatch notifications for appointment changes.
+
+    In production this should integrate with email/SMS providers. For now we
+    log the event so downstream systems can subscribe.
+    """
+    logger.info(
+        "Appointment %s: patient=%s provider=%s start=%s status=%s",
+        event,
+        appointment.patient_id,
+        appointment.provider_id,
+        appointment.start_time.isoformat(),
+        appointment.status,
+    )
+    notifications = list(appointment.notifications_sent or [])
+    notifications.append(event)
+    Appointment.objects.filter(pk=appointment.pk).update(notifications_sent=notifications)

--- a/apps/appointments/serializers.py
+++ b/apps/appointments/serializers.py
@@ -1,0 +1,121 @@
+"""
+Serializers for appointment scheduling.
+"""
+
+from datetime import timedelta
+
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+from apps.core.models import HealthFacility, User
+from apps.patients.models import Patient
+
+from .models import Appointment
+
+
+class AppointmentSerializer(serializers.ModelSerializer):
+    """
+    Lightweight serializer for listing appointments.
+    """
+
+    patient_name = serializers.CharField(source="patient.get_full_name", read_only=True)
+    provider_name = serializers.CharField(source="provider.get_full_name", read_only=True)
+    facility_name = serializers.CharField(source="facility.name", read_only=True)
+
+    class Meta:
+        model = Appointment
+        fields = [
+            "id",
+            "patient",
+            "patient_name",
+            "provider",
+            "provider_name",
+            "facility",
+            "facility_name",
+            "appointment_type",
+            "reason",
+            "status",
+            "start_time",
+            "end_time",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class AppointmentDetailSerializer(AppointmentSerializer):
+    """
+    Detailed serializer that includes notification metadata.
+    """
+
+    class Meta(AppointmentSerializer.Meta):
+        fields = AppointmentSerializer.Meta.fields + ["notifications_sent"]
+        read_only_fields = AppointmentSerializer.Meta.read_only_fields + ["notifications_sent"]
+
+
+class AppointmentCreateSerializer(serializers.ModelSerializer):
+    """
+    Serializer for creating and updating appointments with conflict detection.
+    """
+
+    class Meta:
+        model = Appointment
+        fields = [
+            "patient",
+            "provider",
+            "facility",
+            "appointment_type",
+            "reason",
+            "status",
+            "start_time",
+            "end_time",
+        ]
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        start = attrs.get("start_time") or getattr(self.instance, "start_time", None)
+        end = attrs.get("end_time") or getattr(self.instance, "end_time", None)
+        if start is None or end is None:
+            raise serializers.ValidationError(_("Start and end times are required."))
+        if start >= end:
+            raise serializers.ValidationError(_("End time must be after start time."))
+        if end - start < timedelta(minutes=5):
+            raise serializers.ValidationError(_("Appointment must be at least 5 minutes long."))
+
+        provider = attrs.get("provider") or getattr(self.instance, "provider", None)
+        patient = attrs.get("patient") or getattr(self.instance, "patient", None)
+        facility = attrs.get("facility") or getattr(self.instance, "facility", None)
+
+        if provider and provider.user_type not in {"doctor", "nurse", "midwife", "community_worker"}:
+            raise serializers.ValidationError(_("Selected provider is not eligible for appointments."))
+
+        active_statuses = [Appointment.Status.SCHEDULED, Appointment.Status.NO_SHOW]
+        query_kwargs = {"status__in": active_statuses, "start_time__lt": end, "end_time__gt": start}
+        appointments = Appointment.objects.filter(**query_kwargs)
+        if self.instance:
+            appointments = appointments.exclude(pk=self.instance.pk)
+
+        if provider and appointments.filter(provider=provider).exists():
+            raise serializers.ValidationError({"provider": _("Provider already has an appointment in this window.")})
+        if patient and appointments.filter(patient=patient).exists():
+            raise serializers.ValidationError({"patient": _("Patient already has an appointment in this window.")})
+        if facility and appointments.filter(facility=facility).exists():
+            raise serializers.ValidationError({"facility": _("Facility already has an appointment in this window.")})
+
+        return attrs
+
+    def validate_provider(self, value):
+        if not value.is_active:
+            raise serializers.ValidationError(_("Provider account is inactive."))
+        return value
+
+    def validate_patient(self, value):
+        if not value.is_active:
+            raise serializers.ValidationError(_("Patient profile is inactive."))
+        return value
+
+    def create(self, validated_data):
+        request = self.context.get("request")
+        validated_data.setdefault("created_by", getattr(request, "user", None))
+        return super().create(validated_data)

--- a/apps/appointments/serializers.py
+++ b/apps/appointments/serializers.py
@@ -103,6 +103,10 @@ class AppointmentCreateSerializer(serializers.ModelSerializer):
         if facility and appointments.filter(facility=facility).exists():
             raise serializers.ValidationError({"facility": _("Facility already has an appointment in this window.")})
 
+        # Additional validation: check if appointment is in the past
+        if start and start < timezone.now():
+            raise serializers.ValidationError({"start_time": _("Cannot schedule appointments in the past.")})
+
         return attrs
 
     def validate_provider(self, value):

--- a/apps/appointments/tests/test_appointments_api.py
+++ b/apps/appointments/tests/test_appointments_api.py
@@ -1,0 +1,136 @@
+"""
+Tests for the appointment scheduling API.
+"""
+
+from datetime import datetime, timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.core.models import HealthFacility, Location
+from apps.patients.models import Patient
+from apps.appointments.models import Appointment
+
+
+User = get_user_model()
+
+
+class AppointmentAPITests(APITestCase):
+    def setUp(self):
+        self.provider = User.objects.create_user(
+            username="provider1",
+            password="password123",
+            user_type="doctor",
+            first_name="Provider",
+            last_name="One",
+        )
+        self.patient = Patient.objects.create(
+            patient_id="PAT-000100",
+            first_name="Patient",
+            last_name="One",
+            date_of_birth=datetime(1990, 1, 1).date(),
+            gender="M",
+            phone_number="+256701000000",
+            email="patient@example.com",
+            address="123 Wellness Road",
+            location=Location.objects.create(name="Region", location_type="region"),
+            emergency_contact_name="Emergency Contact",
+            emergency_contact_phone="+256701000001",
+            emergency_contact_relationship="Sibling",
+            registered_facility=HealthFacility.objects.create(
+                name="Hope Clinic",
+                facility_type="clinic",
+                location=Location.objects.create(name="District", location_type="district"),
+                address="456 Care Street",
+                phone_number="+256701000002",
+                email="clinic@example.com",
+                website="",
+                is_24_hours=False,
+                contact_person_name="Admin",
+                contact_person_phone="+256701000003",
+                services_offered=[],
+            ),
+        )
+        self.facility = self.patient.registered_facility
+        self.client.force_authenticate(self.provider)
+        self.list_url = reverse("api:appointment-list")
+
+    def _appointment_payload(self, **kwargs):
+        start = timezone.now() + timedelta(hours=1)
+        end = start + timedelta(minutes=30)
+        payload = {
+            "patient": self.patient.pk,
+            "provider": self.provider.pk,
+            "facility": self.facility.pk,
+            "appointment_type": "consultation",
+            "reason": "Routine checkup",
+            "status": Appointment.Status.SCHEDULED,
+            "start_time": start.isoformat(),
+            "end_time": end.isoformat(),
+        }
+        payload.update(kwargs)
+        return payload
+
+    def test_create_appointment(self):
+        response = self.client.post(self.list_url, data=self._appointment_payload(), format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Appointment.objects.count(), 1)
+        appointment = Appointment.objects.first()
+        self.assertEqual(appointment.provider, self.provider)
+        self.assertIn("created", appointment.notifications_sent)
+
+    def test_provider_conflict_detection(self):
+        self.client.post(self.list_url, data=self._appointment_payload(), format="json")
+        response = self.client.post(self.list_url, data=self._appointment_payload(), format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("provider", response.data)
+
+    def test_patient_conflict_detection(self):
+        another_provider = User.objects.create_user(
+            username="provider2",
+            password="password123",
+            user_type="doctor",
+            first_name="Provider",
+            last_name="Two",
+        )
+        self.client.post(self.list_url, data=self._appointment_payload(), format="json")
+        payload = self._appointment_payload(provider=another_provider.pk)
+        response = self.client.post(self.list_url, data=payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("patient", response.data)
+
+    def test_facility_conflict_detection(self):
+        another_patient = Patient.objects.create(
+            patient_id="PAT-000101",
+            first_name="Patient",
+            last_name="Two",
+            date_of_birth=datetime(1992, 1, 1).date(),
+            gender="F",
+            phone_number="+256701000010",
+            email="patient2@example.com",
+            address="789 Health Road",
+            location=self.patient.location,
+            emergency_contact_name="Emergency2",
+            emergency_contact_phone="+256701000011",
+            emergency_contact_relationship="Parent",
+            registered_facility=self.facility,
+        )
+        self.client.post(self.list_url, data=self._appointment_payload(), format="json")
+        payload = self._appointment_payload(patient=another_patient.pk)
+        response = self.client.post(self.list_url, data=payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("facility", response.data)
+
+    def test_admin_can_view_audit_logs_for_appointments(self):
+        self.client.post(self.list_url, data=self._appointment_payload(), format="json")
+        admin_user = User.objects.create_superuser(
+            username="admin",
+            email="admin@example.com",
+            password="password123",
+        )
+        self.client.force_authenticate(admin_user)
+        response = self.client.get(reverse("api:audit-logs-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/apps/appointments/tests/test_appointments_api.py
+++ b/apps/appointments/tests/test_appointments_api.py
@@ -1,5 +1,5 @@
 """
-Tests for the appointment scheduling API.
+Comprehensive tests for the appointment scheduling API.
 """
 
 from datetime import datetime, timedelta
@@ -19,14 +19,38 @@ User = get_user_model()
 
 
 class AppointmentAPITests(APITestCase):
+    """Test appointment CRUD operations and conflict detection."""
+
     def setUp(self):
+        self.location = Location.objects.create(
+            name="Central Region",
+            location_type="region"
+        )
+        self.facility = HealthFacility.objects.create(
+            name="Hope Clinic",
+            facility_type="clinic",
+            location=self.location,
+            address="456 Care Street",
+            phone_number="+256701000002",
+            email="clinic@example.com",
+            website="",
+            is_24_hours=False,
+            contact_person_name="Admin",
+            contact_person_phone="+256701000003",
+            services_offered=[],
+        )
+        
         self.provider = User.objects.create_user(
             username="provider1",
             password="password123",
             user_type="doctor",
+            role=User.Role.PROVIDER,
             first_name="Provider",
             last_name="One",
+            email="provider@example.com",
+            phone_number="+256701000100",
         )
+        
         self.patient = Patient.objects.create(
             patient_id="PAT-000100",
             first_name="Patient",
@@ -36,29 +60,18 @@ class AppointmentAPITests(APITestCase):
             phone_number="+256701000000",
             email="patient@example.com",
             address="123 Wellness Road",
-            location=Location.objects.create(name="Region", location_type="region"),
+            location=self.location,
             emergency_contact_name="Emergency Contact",
             emergency_contact_phone="+256701000001",
             emergency_contact_relationship="Sibling",
-            registered_facility=HealthFacility.objects.create(
-                name="Hope Clinic",
-                facility_type="clinic",
-                location=Location.objects.create(name="District", location_type="district"),
-                address="456 Care Street",
-                phone_number="+256701000002",
-                email="clinic@example.com",
-                website="",
-                is_24_hours=False,
-                contact_person_name="Admin",
-                contact_person_phone="+256701000003",
-                services_offered=[],
-            ),
+            registered_facility=self.facility,
         )
-        self.facility = self.patient.registered_facility
+        
         self.client.force_authenticate(self.provider)
         self.list_url = reverse("api:appointment-list")
 
     def _appointment_payload(self, **kwargs):
+        """Helper to create appointment payload."""
         start = timezone.now() + timedelta(hours=1)
         end = start + timedelta(minutes=30)
         payload = {
@@ -75,34 +88,111 @@ class AppointmentAPITests(APITestCase):
         return payload
 
     def test_create_appointment(self):
+        """Test creating a new appointment."""
         response = self.client.post(self.list_url, data=self._appointment_payload(), format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Appointment.objects.count(), 1)
         appointment = Appointment.objects.first()
         self.assertEqual(appointment.provider, self.provider)
-        self.assertIn("created", appointment.notifications_sent)
+        self.assertEqual(appointment.patient, self.patient)
+        self.assertEqual(appointment.status, Appointment.Status.SCHEDULED)
+
+    def test_list_appointments(self):
+        """Test listing appointments."""
+        Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=1, minutes=30),
+        )
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+
+    def test_retrieve_appointment(self):
+        """Test retrieving a single appointment."""
+        appointment = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=1, minutes=30),
+        )
+        url = reverse("api:appointment-detail", args=[appointment.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], appointment.pk)
+
+    def test_update_appointment(self):
+        """Test updating an appointment."""
+        appointment = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=1, minutes=30),
+        )
+        url = reverse("api:appointment-detail", args=[appointment.pk])
+        new_reason = "Follow-up consultation"
+        response = self.client.patch(url, {"reason": new_reason}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        appointment.refresh_from_db()
+        self.assertEqual(appointment.reason, new_reason)
+
+    def test_delete_appointment(self):
+        """Test deleting an appointment."""
+        appointment = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=1, minutes=30),
+        )
+        url = reverse("api:appointment-detail", args=[appointment.pk])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Appointment.objects.filter(pk=appointment.pk).exists())
 
     def test_provider_conflict_detection(self):
+        """Test that provider cannot have overlapping appointments."""
         self.client.post(self.list_url, data=self._appointment_payload(), format="json")
-        response = self.client.post(self.list_url, data=self._appointment_payload(), format="json")
+        # Try to create another appointment with same provider at overlapping time
+        start = timezone.now() + timedelta(hours=1, minutes=15)
+        end = start + timedelta(minutes=30)
+        payload = self._appointment_payload(
+            start_time=start.isoformat(),
+            end_time=end.isoformat()
+        )
+        response = self.client.post(self.list_url, data=payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("provider", response.data)
 
     def test_patient_conflict_detection(self):
+        """Test that patient cannot have overlapping appointments."""
         another_provider = User.objects.create_user(
             username="provider2",
             password="password123",
             user_type="doctor",
+            role=User.Role.PROVIDER,
             first_name="Provider",
             last_name="Two",
         )
         self.client.post(self.list_url, data=self._appointment_payload(), format="json")
-        payload = self._appointment_payload(provider=another_provider.pk)
+        # Try to create another appointment with same patient at overlapping time
+        start = timezone.now() + timedelta(hours=1, minutes=15)
+        end = start + timedelta(minutes=30)
+        payload = self._appointment_payload(
+            provider=another_provider.pk,
+            start_time=start.isoformat(),
+            end_time=end.isoformat()
+        )
         response = self.client.post(self.list_url, data=payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("patient", response.data)
 
     def test_facility_conflict_detection(self):
+        """Test that facility cannot have overlapping appointments."""
         another_patient = Patient.objects.create(
             patient_id="PAT-000101",
             first_name="Patient",
@@ -112,25 +202,230 @@ class AppointmentAPITests(APITestCase):
             phone_number="+256701000010",
             email="patient2@example.com",
             address="789 Health Road",
-            location=self.patient.location,
+            location=self.location,
             emergency_contact_name="Emergency2",
             emergency_contact_phone="+256701000011",
             emergency_contact_relationship="Parent",
             registered_facility=self.facility,
         )
         self.client.post(self.list_url, data=self._appointment_payload(), format="json")
-        payload = self._appointment_payload(patient=another_patient.pk)
+        # Try to create another appointment at same facility at overlapping time
+        start = timezone.now() + timedelta(hours=1, minutes=15)
+        end = start + timedelta(minutes=30)
+        payload = self._appointment_payload(
+            patient=another_patient.pk,
+            start_time=start.isoformat(),
+            end_time=end.isoformat()
+        )
         response = self.client.post(self.list_url, data=payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("facility", response.data)
 
-    def test_admin_can_view_audit_logs_for_appointments(self):
-        self.client.post(self.list_url, data=self._appointment_payload(), format="json")
+    def test_cannot_schedule_in_past(self):
+        """Test that appointments cannot be scheduled in the past."""
+        past_time = timezone.now() - timedelta(hours=1)
+        payload = self._appointment_payload(
+            start_time=past_time.isoformat(),
+            end_time=(past_time + timedelta(minutes=30)).isoformat()
+        )
+        response = self.client.post(self.list_url, data=payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("start_time", response.data)
+
+    def test_minimum_duration_validation(self):
+        """Test that appointments must be at least 5 minutes long."""
+        start = timezone.now() + timedelta(hours=1)
+        end = start + timedelta(minutes=3)  # Too short
+        payload = self._appointment_payload(
+            start_time=start.isoformat(),
+            end_time=end.isoformat()
+        )
+        response = self.client.post(self.list_url, data=payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_upcoming_appointments_action(self):
+        """Test the upcoming appointments endpoint."""
+        # Create past appointment
+        Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() - timedelta(hours=1),
+            end_time=timezone.now() - timedelta(minutes=30),
+            status=Appointment.Status.SCHEDULED,
+        )
+        # Create future appointment
+        future_appointment = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=1, minutes=30),
+            status=Appointment.Status.SCHEDULED,
+        )
+        url = reverse("api:appointment-upcoming")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], future_appointment.pk)
+
+    def test_by_provider_action(self):
+        """Test filtering appointments by provider."""
+        another_provider = User.objects.create_user(
+            username="provider2",
+            password="password123",
+            user_type="nurse",
+            role=User.Role.PROVIDER,
+        )
+        appointment1 = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=1, minutes=30),
+        )
+        Appointment.objects.create(
+            patient=self.patient,
+            provider=another_provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=2),
+            end_time=timezone.now() + timedelta(hours=2, minutes=30),
+        )
+        url = reverse("api:appointment-by-provider", args=[self.provider.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], appointment1.pk)
+
+    def test_by_patient_action(self):
+        """Test filtering appointments by patient."""
+        another_patient = Patient.objects.create(
+            patient_id="PAT-000102",
+            first_name="Patient",
+            last_name="Three",
+            date_of_birth=datetime(1993, 1, 1).date(),
+            gender="F",
+            phone_number="+256701000020",
+            email="patient3@example.com",
+            address="999 Health Road",
+            location=self.location,
+            emergency_contact_name="Emergency3",
+            emergency_contact_phone="+256701000021",
+            emergency_contact_relationship="Spouse",
+            registered_facility=self.facility,
+        )
+        appointment1 = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=1, minutes=30),
+        )
+        Appointment.objects.create(
+            patient=another_patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=2),
+            end_time=timezone.now() + timedelta(hours=2, minutes=30),
+        )
+        url = reverse("api:appointment-by-patient", args=[self.patient.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], appointment1.pk)
+
+    def test_cancel_appointment_action(self):
+        """Test cancelling an appointment."""
+        appointment = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=1, minutes=30),
+            status=Appointment.Status.SCHEDULED,
+        )
+        url = reverse("api:appointment-cancel", args=[appointment.pk])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        appointment.refresh_from_db()
+        self.assertEqual(appointment.status, Appointment.Status.CANCELLED)
+
+    def test_complete_appointment_action(self):
+        """Test marking an appointment as completed."""
+        appointment = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() - timedelta(hours=1),
+            end_time=timezone.now() - timedelta(minutes=30),
+            status=Appointment.Status.SCHEDULED,
+        )
+        url = reverse("api:appointment-complete", args=[appointment.pk])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        appointment.refresh_from_db()
+        self.assertEqual(appointment.status, Appointment.Status.COMPLETED)
+
+    def test_mark_no_show_action(self):
+        """Test marking an appointment as no-show."""
+        appointment = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() - timedelta(hours=1),
+            end_time=timezone.now() - timedelta(minutes=30),
+            status=Appointment.Status.SCHEDULED,
+        )
+        url = reverse("api:appointment-mark-no-show", args=[appointment.pk])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        appointment.refresh_from_db()
+        self.assertEqual(appointment.status, Appointment.Status.NO_SHOW)
+
+    def test_check_conflicts_action(self):
+        """Test the check conflicts endpoint."""
+        appointment1 = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1),
+            end_time=timezone.now() + timedelta(hours=1, minutes=30),
+            status=Appointment.Status.SCHEDULED,
+        )
+        # Create overlapping appointment
+        appointment2 = Appointment.objects.create(
+            patient=self.patient,
+            provider=self.provider,
+            facility=self.facility,
+            start_time=timezone.now() + timedelta(hours=1, minutes=15),
+            end_time=timezone.now() + timedelta(hours=1, minutes=45),
+            status=Appointment.Status.SCHEDULED,
+        )
+        url = reverse("api:appointment-check-conflicts", args=[appointment2.pk])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["has_conflicts"])
+
+    def test_rbac_patient_blocked(self):
+        """Test that patients cannot access appointment endpoints."""
+        patient_user = User.objects.create_user(
+            username="patient_user",
+            password="password123",
+            role=User.Role.PATIENT,
+            email="patient_user@example.com",
+        )
+        self.client.force_authenticate(patient_user)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_rbac_admin_can_access(self):
+        """Test that admins can access appointment endpoints."""
         admin_user = User.objects.create_superuser(
             username="admin",
             email="admin@example.com",
             password="password123",
+            role=User.Role.ADMIN,
         )
         self.client.force_authenticate(admin_user)
-        response = self.client.get(reverse("api:audit-logs-list"))
+        response = self.client.get(self.list_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/apps/appointments/views.py
+++ b/apps/appointments/views.py
@@ -1,0 +1,69 @@
+"""
+ViewSet for appointment scheduling.
+"""
+
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+
+from apps.api.mixins import AuditLogMixin
+from .models import Appointment
+from .serializers import (
+    AppointmentCreateSerializer,
+    AppointmentDetailSerializer,
+    AppointmentSerializer,
+)
+from .notifications import send_notification
+
+
+class AppointmentViewSet(AuditLogMixin, viewsets.ModelViewSet):
+    """
+    Manage patient-provider appointments with conflict detection.
+    """
+
+    queryset = (
+        Appointment.objects.select_related("patient", "provider", "facility")
+        .all()
+    )
+    permission_classes = [IsAuthenticated]
+    serializer_class = AppointmentSerializer
+    filterset_fields = [
+        "provider",
+        "patient",
+        "facility",
+        "status",
+        "appointment_type",
+    ]
+    search_fields = [
+        "patient__patient_id",
+        "patient__first_name",
+        "patient__last_name",
+        "provider__first_name",
+        "provider__last_name",
+    ]
+    ordering_fields = ["start_time", "created_at"]
+    ordering = ["start_time"]
+
+    serializer_action_map = {
+        "list": AppointmentSerializer,
+        "retrieve": AppointmentDetailSerializer,
+        "create": AppointmentCreateSerializer,
+        "update": AppointmentCreateSerializer,
+        "partial_update": AppointmentCreateSerializer,
+    }
+
+    def get_serializer_class(self):
+        return self.serializer_action_map.get(self.action, self.serializer_class)
+
+    def perform_create(self, serializer):
+        appointment = super().perform_create(serializer)
+        send_notification(appointment, "created")
+        return appointment
+
+    def perform_update(self, serializer):
+        appointment = super().perform_update(serializer)
+        send_notification(appointment, "updated")
+        return appointment
+
+    def perform_destroy(self, instance):
+        send_notification(instance, "cancelled")
+        super().perform_destroy(instance)

--- a/apps/appointments/views.py
+++ b/apps/appointments/views.py
@@ -2,10 +2,15 @@
 ViewSet for appointment scheduling.
 """
 
-from rest_framework import viewsets
+from django.utils import timezone
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from apps.api.mixins import AuditLogMixin
+from apps.api.permissions import RoleRequired
+from django.contrib.auth import get_user_model
 from .models import Appointment
 from .serializers import (
     AppointmentCreateSerializer,
@@ -14,6 +19,8 @@ from .serializers import (
 )
 from .notifications import send_notification
 
+User = get_user_model()
+
 
 class AppointmentViewSet(AuditLogMixin, viewsets.ModelViewSet):
     """
@@ -21,10 +28,11 @@ class AppointmentViewSet(AuditLogMixin, viewsets.ModelViewSet):
     """
 
     queryset = (
-        Appointment.objects.select_related("patient", "provider", "facility")
+        Appointment.objects.select_related("patient", "provider", "facility", "created_by")
         .all()
     )
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, RoleRequired]
+    required_roles = frozenset({User.Role.ADMIN, User.Role.PROVIDER})
     serializer_class = AppointmentSerializer
     filterset_fields = [
         "provider",
@@ -67,3 +75,92 @@ class AppointmentViewSet(AuditLogMixin, viewsets.ModelViewSet):
     def perform_destroy(self, instance):
         send_notification(instance, "cancelled")
         super().perform_destroy(instance)
+
+    @action(detail=False, methods=["get"], url_path="upcoming")
+    def upcoming(self, request):
+        """Get all upcoming appointments."""
+        now = timezone.now()
+        queryset = self.get_queryset().filter(
+            start_time__gt=now,
+            status=Appointment.Status.SCHEDULED
+        )
+        page = self.paginate_queryset(queryset)
+        serializer = self.get_serializer(page or queryset, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    @action(detail=False, methods=["get"], url_path="by-provider/(?P<provider_id>[^/.]+)")
+    def by_provider(self, request, provider_id=None):
+        """Get appointments for a specific provider."""
+        queryset = self.get_queryset().filter(provider_id=provider_id)
+        page = self.paginate_queryset(queryset)
+        serializer = self.get_serializer(page or queryset, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    @action(detail=False, methods=["get"], url_path="by-patient/(?P<patient_id>[^/.]+)")
+    def by_patient(self, request, patient_id=None):
+        """Get appointments for a specific patient."""
+        queryset = self.get_queryset().filter(patient_id=patient_id)
+        page = self.paginate_queryset(queryset)
+        serializer = self.get_serializer(page or queryset, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["post"], url_path="check-conflicts")
+    def check_conflicts(self, request, pk=None):
+        """Check for scheduling conflicts for this appointment."""
+        appointment = self.get_object()
+        conflicts = appointment.check_conflicts(exclude_pk=appointment.pk)
+        return Response({
+            "has_conflicts": conflicts is not None,
+            "conflicts": conflicts or {}
+        })
+
+    @action(detail=True, methods=["post"], url_path="cancel")
+    def cancel(self, request, pk=None):
+        """Cancel an appointment."""
+        appointment = self.get_object()
+        if appointment.status == Appointment.Status.CANCELLED:
+            return Response(
+                {"error": "Appointment is already cancelled."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        appointment.status = Appointment.Status.CANCELLED
+        appointment.save()
+        send_notification(appointment, "cancelled")
+        serializer = self.get_serializer(appointment)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["post"], url_path="complete")
+    def complete(self, request, pk=None):
+        """Mark an appointment as completed."""
+        appointment = self.get_object()
+        if appointment.status == Appointment.Status.COMPLETED:
+            return Response(
+                {"error": "Appointment is already completed."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        appointment.status = Appointment.Status.COMPLETED
+        appointment.save()
+        send_notification(appointment, "updated")
+        serializer = self.get_serializer(appointment)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["post"], url_path="mark-no-show")
+    def mark_no_show(self, request, pk=None):
+        """Mark an appointment as no-show."""
+        appointment = self.get_object()
+        if appointment.status == Appointment.Status.NO_SHOW:
+            return Response(
+                {"error": "Appointment is already marked as no-show."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        appointment.status = Appointment.Status.NO_SHOW
+        appointment.save()
+        send_notification(appointment, "updated")
+        serializer = self.get_serializer(appointment)
+        return Response(serializer.data)

--- a/apps/core/admin.py
+++ b/apps/core/admin.py
@@ -19,11 +19,11 @@ class UserAdmin(BaseUserAdmin):
     Admin interface for User model.
     """
     list_display = [
-        'username', 'email', 'first_name', 'last_name', 'user_type',
+        'username', 'email', 'first_name', 'last_name', 'role', 'user_type',
         'phone_number', 'is_active', 'date_joined', 'last_login'
     ]
     list_filter = [
-        'user_type', 'is_active', 'is_staff', 'is_superuser',
+        'role', 'user_type', 'is_active', 'is_staff', 'is_superuser',
         'date_joined', 'last_login'
     ]
     search_fields = ['username', 'first_name', 'last_name', 'email', 'phone_number']
@@ -39,7 +39,7 @@ class UserAdmin(BaseUserAdmin):
         }),
         (_('Professional info'), {
             'fields': (
-                'user_type', 'license_number', 'specialization',
+                'role', 'user_type', 'license_number', 'specialization',
                 'years_of_experience'
             )
         }),
@@ -57,7 +57,7 @@ class UserAdmin(BaseUserAdmin):
             'classes': ('wide',),
             'fields': (
                 'username', 'email', 'password1', 'password2',
-                'first_name', 'last_name', 'user_type'
+                'first_name', 'last_name', 'role', 'user_type'
             ),
         }),
     )

--- a/apps/core/migrations/0001_add_role_field.py
+++ b/apps/core/migrations/0001_add_role_field.py
@@ -1,0 +1,24 @@
+# Generated migration for adding role field to User model
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '__first__'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='role',
+            field=models.CharField(
+                choices=[('admin', 'Administrator'), ('provider', 'Healthcare Provider'), ('patient', 'Patient')],
+                default='provider',
+                help_text='High-level persona used for role-based access control.',
+                max_length=20
+            ),
+        ),
+    ]
+

--- a/apps/core/migrations/0002_set_admin_role_default.py
+++ b/apps/core/migrations/0002_set_admin_role_default.py
@@ -1,0 +1,21 @@
+# Generated migration for setting admin role for superusers
+
+from django.db import migrations
+
+
+def _set_admin_role(apps, schema_editor):
+    """Set admin role for existing superusers."""
+    User = apps.get_model("core", "User")
+    User.objects.filter(is_superuser=True).update(role="admin")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0001_add_role_field"),
+    ]
+
+    operations = [
+        migrations.RunPython(_set_admin_role, migrations.RunPython.noop),
+    ]
+

--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -12,6 +12,11 @@ class User(AbstractUser):
     """
     Custom user model for health workers and administrators.
     """
+    class Role(models.TextChoices):
+        ADMIN = 'admin', _('Administrator')
+        PROVIDER = 'provider', _('Healthcare Provider')
+        PATIENT = 'patient', _('Patient')
+
     USER_TYPE_CHOICES = [
         ('admin', _('Administrator')),
         ('doctor', _('Doctor')),
@@ -22,6 +27,12 @@ class User(AbstractUser):
         ('lab_technician', _('Laboratory Technician')),
     ]
     
+    role = models.CharField(
+        max_length=20,
+        choices=Role.choices,
+        default=Role.PROVIDER,
+        help_text=_('High-level persona used for role-based access control.')
+    )
     user_type = models.CharField(
         max_length=20,
         choices=USER_TYPE_CHOICES,
@@ -53,6 +64,21 @@ class User(AbstractUser):
     
     def __str__(self):
         return f"{self.get_full_name()} ({self.get_user_type_display()})"
+
+    @property
+    def is_admin_role(self):
+        """Check if user has admin role."""
+        return self.role == self.Role.ADMIN
+
+    @property
+    def is_provider_role(self):
+        """Check if user has provider role."""
+        return self.role == self.Role.PROVIDER
+
+    @property
+    def is_patient_role(self):
+        """Check if user has patient role."""
+        return self.role == self.Role.PATIENT
 
 
 class Location(models.Model):

--- a/apps/records/filters.py
+++ b/apps/records/filters.py
@@ -1,0 +1,38 @@
+"""
+Filter definitions for health record queries.
+"""
+
+from __future__ import annotations
+
+import django_filters
+
+from .models import HealthRecord
+
+
+class HealthRecordFilter(django_filters.FilterSet):
+    """
+    Provide rich filtering options for health record collections.
+
+    Supports record date ranges, facility/provider scoping, and partial patient
+    ID searches so clinicians can rapidly locate relevant entries.
+    """
+
+    record_date = django_filters.DateFromToRangeFilter()
+    patient_id = django_filters.CharFilter(
+        field_name="patient__patient_id", lookup_expr="icontains"
+    )
+    provider = django_filters.NumberFilter(field_name="attending_provider")
+    facility = django_filters.NumberFilter(field_name="facility")
+    record_type = django_filters.CharFilter(field_name="record_type")
+
+    class Meta:
+        model = HealthRecord
+        fields = [
+            "record_date",
+            "patient",
+            "patient_id",
+            "provider",
+            "facility",
+            "record_type",
+            "is_confidential",
+        ]

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -47,6 +47,7 @@ LOCAL_APPS = [
     'apps.records',
     'apps.analytics',
     'apps.api',
+    'apps.appointments',
 ]
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS

--- a/docs/appointments.md
+++ b/docs/appointments.md
@@ -1,0 +1,37 @@
+# Appointment Scheduling API
+
+The appointment scheduling endpoints coordinate visits between patients and
+healthcare providers. This guide summarizes the request flow and safeguards.
+
+## Endpoints
+
+- `GET /api/v1/appointments/`: List upcoming appointments (filterable by patient,
+  provider, facility, status, or type).
+- `POST /api/v1/appointments/`: Create a new appointment.
+- `GET /api/v1/appointments/{id}/`: Retrieve appointment details.
+- `PATCH /api/v1/appointments/{id}/`: Update status, timing, or metadata.
+- `DELETE /api/v1/appointments/{id}/`: Cancel an appointment (audit logged).
+
+All endpoints require authentication. CRUD operations are audit logged through
+the shared `AuditLogMixin`.
+
+## Conflict Detection
+
+- Provider, patient, and facility calendars are checked for overlapping time
+  ranges before saving.
+- Appointments shorter than five minutes or with `start_time >= end_time` are
+  rejected.
+- Only active clinical user types (doctor, nurse, midwife, community_worker)
+  may be assigned as the provider.
+
+## Notifications
+
+- Each create/update/delete action triggers `apps.appointments.notifications.send_notification`.
+- The current implementation logs to the application logger and records the
+  emitted events on the appointment record.
+- Integrate email/SMS by replacing the logger call inside the notification helper.
+
+## Testing
+
+Unit tests cover conflict detection for providers, patients, and facilities, and
+verify that API responses behave as expected (`apps/appointments/tests/test_appointments_api.py`).

--- a/docs/appointments.md
+++ b/docs/appointments.md
@@ -1,37 +1,365 @@
 # Appointment Scheduling API
 
-The appointment scheduling endpoints coordinate visits between patients and
-healthcare providers. This guide summarizes the request flow and safeguards.
+The Appointment Scheduling API provides comprehensive endpoints for managing appointments between patients and healthcare providers. It includes conflict detection, notification hooks, and role-based access control.
+
+## Overview
+
+The appointment system ensures:
+- **No double booking**: Prevents overlapping appointments for providers, patients, and facilities
+- **Automatic notifications**: Sends email and SMS notifications for appointment events
+- **Role-based access**: Only admins and providers can manage appointments
+- **Status management**: Track appointment lifecycle (scheduled, completed, cancelled, no-show)
 
 ## Endpoints
 
-- `GET /api/v1/appointments/`: List upcoming appointments (filterable by patient,
-  provider, facility, status, or type).
-- `POST /api/v1/appointments/`: Create a new appointment.
-- `GET /api/v1/appointments/{id}/`: Retrieve appointment details.
-- `PATCH /api/v1/appointments/{id}/`: Update status, timing, or metadata.
-- `DELETE /api/v1/appointments/{id}/`: Cancel an appointment (audit logged).
+### Base URL
+All appointment endpoints are under `/api/v1/appointments/`
 
-All endpoints require authentication. CRUD operations are audit logged through
-the shared `AuditLogMixin`.
+### CRUD Operations
+
+#### List Appointments
+```
+GET /api/v1/appointments/
+```
+Returns paginated list of appointments with filtering and search support.
+
+**Query Parameters:**
+- `provider` - Filter by provider ID
+- `patient` - Filter by patient ID
+- `facility` - Filter by facility ID
+- `status` - Filter by status (scheduled, completed, cancelled, no_show)
+- `appointment_type` - Filter by appointment type
+- `search` - Search by patient ID, patient name, or provider name
+- `ordering` - Order by `start_time` or `created_at` (default: `start_time`)
+
+**Response:**
+```json
+{
+  "count": 10,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "patient": 1,
+      "patient_name": "John Doe",
+      "provider": 5,
+      "provider_name": "Dr. Jane Smith",
+      "facility": 3,
+      "facility_name": "Hope Clinic",
+      "appointment_type": "consultation",
+      "reason": "Routine checkup",
+      "status": "scheduled",
+      "start_time": "2025-01-15T10:00:00Z",
+      "end_time": "2025-01-15T10:30:00Z",
+      "created_at": "2025-01-10T08:00:00Z",
+      "updated_at": "2025-01-10T08:00:00Z"
+    }
+  ]
+}
+```
+
+#### Create Appointment
+```
+POST /api/v1/appointments/
+```
+Creates a new appointment with automatic conflict detection and notifications.
+
+**Request Body:**
+```json
+{
+  "patient": 1,
+  "provider": 5,
+  "facility": 3,
+  "appointment_type": "consultation",
+  "reason": "Routine checkup",
+  "start_time": "2025-01-15T10:00:00Z",
+  "end_time": "2025-01-15T10:30:00Z"
+}
+```
+
+**Validation Rules:**
+- `start_time` must be in the future
+- `end_time` must be after `start_time`
+- Minimum duration: 5 minutes
+- No overlapping appointments for provider, patient, or facility
+- Provider must be active and eligible (doctor, nurse, midwife, community_worker)
+- Patient must be active
+
+**Response:** `201 Created` with appointment details
+
+**Error Responses:**
+- `400 Bad Request` - Validation errors or conflicts
+  ```json
+  {
+    "provider": ["Provider already has an appointment in this window."],
+    "patient": ["Patient already has an appointment in this window."],
+    "facility": ["Facility already has an appointment in this window."]
+  }
+  ```
+
+#### Retrieve Appointment
+```
+GET /api/v1/appointments/{id}/
+```
+Returns detailed appointment information including notification history.
+
+**Response:**
+```json
+{
+  "id": 1,
+  "patient": 1,
+  "patient_name": "John Doe",
+  "provider": 5,
+  "provider_name": "Dr. Jane Smith",
+  "facility": 3,
+  "facility_name": "Hope Clinic",
+  "appointment_type": "consultation",
+  "reason": "Routine checkup",
+  "status": "scheduled",
+  "start_time": "2025-01-15T10:00:00Z",
+  "end_time": "2025-01-15T10:30:00Z",
+  "notifications_sent": [
+    {
+      "type": "email",
+      "recipient": "patient",
+      "method": "email",
+      "sent_at": "2025-01-10T08:00:00Z"
+    }
+  ],
+  "created_at": "2025-01-10T08:00:00Z",
+  "updated_at": "2025-01-10T08:00:00Z"
+}
+```
+
+#### Update Appointment
+```
+PATCH /api/v1/appointments/{id}/
+PUT /api/v1/appointments/{id}/
+```
+Updates appointment details. Triggers conflict detection and notifications.
+
+**Request Body:** (same as create, all fields optional)
+
+**Response:** `200 OK` with updated appointment
+
+#### Delete Appointment
+```
+DELETE /api/v1/appointments/{id}/
+```
+Cancels and deletes an appointment. Sends cancellation notifications.
+
+**Response:** `204 No Content`
+
+### Custom Actions
+
+#### Upcoming Appointments
+```
+GET /api/v1/appointments/upcoming/
+```
+Returns all scheduled appointments in the future.
+
+**Response:** Same format as list endpoint, filtered to future scheduled appointments only.
+
+#### Appointments by Provider
+```
+GET /api/v1/appointments/by-provider/{provider_id}/
+```
+Returns all appointments for a specific provider.
+
+**Response:** Same format as list endpoint.
+
+#### Appointments by Patient
+```
+GET /api/v1/appointments/by-patient/{patient_id}/
+```
+Returns all appointments for a specific patient.
+
+**Response:** Same format as list endpoint.
+
+#### Check Conflicts
+```
+POST /api/v1/appointments/{id}/check-conflicts/
+```
+Manually check for scheduling conflicts for an appointment.
+
+**Response:**
+```json
+{
+  "has_conflicts": true,
+  "conflicts": {
+    "provider": [
+      {
+        "id": 2,
+        "start_time": "2025-01-15T10:15:00Z",
+        "end_time": "2025-01-15T10:45:00Z",
+        "patient__first_name": "Jane",
+        "patient__last_name": "Doe"
+      }
+    ]
+  }
+}
+```
+
+#### Cancel Appointment
+```
+POST /api/v1/appointments/{id}/cancel/
+```
+Marks an appointment as cancelled and sends notifications.
+
+**Response:** `200 OK` with updated appointment (status: "cancelled")
+
+#### Complete Appointment
+```
+POST /api/v1/appointments/{id}/complete/
+```
+Marks an appointment as completed.
+
+**Response:** `200 OK` with updated appointment (status: "completed")
+
+#### Mark No-Show
+```
+POST /api/v1/appointments/{id}/mark-no-show/
+```
+Marks an appointment as no-show.
+
+**Response:** `200 OK` with updated appointment (status: "no_show")
 
 ## Conflict Detection
 
-- Provider, patient, and facility calendars are checked for overlapping time
-  ranges before saving.
-- Appointments shorter than five minutes or with `start_time >= end_time` are
-  rejected.
-- Only active clinical user types (doctor, nurse, midwife, community_worker)
-  may be assigned as the provider.
+The system prevents double booking by checking for overlapping appointments:
+
+1. **Provider conflicts**: A provider cannot have two appointments at the same time
+2. **Patient conflicts**: A patient cannot have two appointments at the same time
+3. **Facility conflicts**: A facility cannot have two appointments at the same time
+
+**Conflict Detection Logic:**
+- Only considers appointments with status `scheduled` or `no_show`
+- Checks for time overlap: `start_time < other.end_time AND end_time > other.start_time`
+- Validates during create and update operations
+- Can be manually checked using the `check-conflicts` endpoint
 
 ## Notifications
 
-- Each create/update/delete action triggers `apps.appointments.notifications.send_notification`.
-- The current implementation logs to the application logger and records the
-  emitted events on the appointment record.
-- Integrate email/SMS by replacing the logger call inside the notification helper.
+The system automatically sends notifications for appointment events:
+
+### Events
+- **created**: When a new appointment is scheduled
+- **updated**: When appointment details are changed
+- **cancelled**: When an appointment is cancelled
+- **reminder**: (Future) For appointment reminders
+
+### Notification Methods
+
+#### Email Notifications
+- Sent to both patient and provider email addresses
+- Includes appointment details, date/time, facility, and reason
+- Subject line includes event type and appointment date
+
+#### SMS Notifications
+- Sent to both patient and provider phone numbers
+- Shorter format optimized for SMS
+- Includes key details: date, time, provider/facility name
+
+### Notification Hooks
+
+The notification system is designed to integrate with:
+- **Email**: Django's `send_mail` (configurable via `DEFAULT_FROM_EMAIL`)
+- **SMS**: Hook ready for integration with:
+  - Twilio
+  - AWS SNS
+  - Africa's Talking
+  - Other SMS gateway services
+
+**Current Implementation:**
+- Email notifications are fully functional
+- SMS notifications are logged (ready for provider integration)
+
+**Notification History:**
+All sent notifications are tracked in the `notifications_sent` field of each appointment.
+
+## Roles & Permissions
+
+- **Admin** (`admin` role): Full access to all appointment operations
+- **Provider** (`provider` role): Can create, view, update, and cancel appointments
+- **Patient** (`patient` role): Currently blocked (future: may view own appointments)
+
+All endpoints require authentication and appropriate role permissions.
+
+## Status Management
+
+Appointments can have the following statuses:
+
+- **scheduled**: Appointment is confirmed and upcoming
+- **completed**: Appointment was successfully completed
+- **cancelled**: Appointment was cancelled
+- **no_show**: Patient did not show up for the appointment
+
+Status transitions:
+- `scheduled` → `completed` (via `complete` action)
+- `scheduled` → `cancelled` (via `cancel` action or delete)
+- `scheduled` → `no_show` (via `mark-no-show` action)
+
+## Model Properties
+
+The Appointment model includes helpful properties:
+
+- `duration_minutes`: Calculates appointment duration in minutes
+- `is_upcoming`: Returns `True` if appointment is in the future and scheduled
+- `check_conflicts()`: Method to manually check for scheduling conflicts
+
+## Example Usage
+
+### Create an Appointment
+```bash
+curl -X POST https://api.opencare-africa.com/api/v1/appointments/ \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "patient": 1,
+    "provider": 5,
+    "facility": 3,
+    "appointment_type": "consultation",
+    "reason": "Annual checkup",
+    "start_time": "2025-01-15T10:00:00Z",
+    "end_time": "2025-01-15T10:30:00Z"
+  }'
+```
+
+### List Upcoming Appointments
+```bash
+curl -X GET https://api.opencare-africa.com/api/v1/appointments/upcoming/ \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+### Cancel an Appointment
+```bash
+curl -X POST https://api.opencare-africa.com/api/v1/appointments/1/cancel/ \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
 
 ## Testing
 
-Unit tests cover conflict detection for providers, patients, and facilities, and
-verify that API responses behave as expected (`apps/appointments/tests/test_appointments_api.py`).
+Comprehensive test coverage includes:
+- CRUD operations
+- Conflict detection (provider, patient, facility)
+- Validation rules (past dates, minimum duration)
+- Custom actions (upcoming, by-provider, by-patient)
+- Status management (cancel, complete, no-show)
+- RBAC enforcement
+- Notification triggers
+
+Run tests with:
+```bash
+python manage.py test apps.appointments.tests.test_appointments_api
+```
+
+## Future Enhancements
+
+- Patient portal access to view own appointments
+- Appointment reminders (24 hours before)
+- Recurring appointments
+- Waitlist management
+- Integration with calendar systems (Google Calendar, Outlook)
+- Video consultation links
+- Appointment ratings and feedback

--- a/docs/patient-records.md
+++ b/docs/patient-records.md
@@ -1,0 +1,53 @@
+# Patient Records API
+
+The patient records API provides secure CRUD access to clinical history across
+OpenCare-Africa. Only authenticated clinical roles (doctor, nurse, midwife,
+lab technician, pharmacist) and superusers may interact with these endpoints.
+
+## Endpoints
+
+- `GET /api/v1/records/` — List records with pagination. Supports filtering on
+  `record_type`, `facility`, `attending_provider`, `patient`, `patient_id`, and
+  `record_date` ranges (`record_date_after`, `record_date_before`).
+- `POST /api/v1/records/` — Create a new record entry.
+- `GET /api/v1/records/{id}/` — Retrieve full clinical details.
+- `PATCH /api/v1/records/{id}/` — Update selected fields.
+- `DELETE /api/v1/records/{id}/` — Remove a record.
+- `GET /api/v1/records/by-patient/?patient_id=PAT-123` — Convenience helper
+  for pulling a patient's entire history by external identifier.
+
+## Roles & Security
+
+- Endpoints require JWT authentication (or a valid session).
+- Only users with clinical roles or superuser privileges pass the permission
+  check enforced by `apps.api.permissions.IsClinicalStaff`.
+- Each response omits sensitive attachments unless requested through the
+  detailed view, helping to balance usability and confidentiality.
+
+## Example Payload
+
+```json
+{
+  "patient": 1,
+  "facility": 3,
+  "record_type": "medical",
+  "record_date": "2025-01-15T10:00:00Z",
+  "attending_provider": 7,
+  "chief_complaint": "Headache",
+  "assessment": "Observation required",
+  "diagnosis": ["tension_headache"],
+  "treatment_plan": "Hydration and rest",
+  "follow_up_plan": "Return if symptoms persist",
+  "notes": "No contraindications noted",
+  "is_confidential": false
+}
+```
+
+## Testing
+
+Automated tests covering create, read, update, delete, filtering, and access
+control live in `apps/api/tests/test_health_records_api.py`. Run them with:
+
+```bash
+python manage.py test apps.api.tests.test_health_records_api
+```

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,76 @@
+# Role-Based Access Control Guide
+
+This guide describes how role-based access control (RBAC) is implemented in OpenCare-Core and how to work with the role metadata introduced for [issue #6](https://github.com/bos-com/OpenCare-Core/issues/6).
+
+## Personas & Capabilities
+
+| Role | Description | Example capabilities |
+|------|-------------|----------------------|
+| `admin` | Platform administrators with broad configuration rights. | Workforce management, system exports, metrics, any provider action. |
+| `provider` | Clinicians and allied health staff interacting with patient data. | Patient CRUD, visit coordination, facility lookup. |
+| `patient` | Individuals accessing their personal health data. | Future-facing patient portal access. Currently blocked from staff endpoints. |
+
+`admin` users implicitly inherit all provider privileges. Patients are intentionally restricted until patient-facing endpoints are introduced.
+
+## API Permission Matrix
+
+| Endpoint | Allowed roles | Notes |
+|----------|---------------|-------|
+| `/api/v1/patients/` | `admin`, `provider` | Patient management reserved for staff. |
+| `/api/v1/health-workers/` | `admin` | Workforce administration only. |
+| `/api/v1/facilities/` | `admin`, `provider` | Operational facility data. |
+| `/api/v1/visits/` | `admin`, `provider` | Visit scheduling and tracking. |
+| `/api/v1/records/` | `admin`, `provider` | Clinical records. Patient self-access is future work. |
+| `/api/v1/audit-logs/` | `admin` | Audit trail access. |
+| `/api/v1/stats/` | `admin` | Operational metrics. |
+| `/api/v1/export/` | `admin` | Bulk data export. |
+| `/api/v1/health/` | Public | Health check kept open for infra probes. |
+
+Additional viewsets should set a `required_roles` frozenset and include `RoleRequired` in `permission_classes` to join the RBAC system.
+
+## Assigning Roles
+
+Users now expose a `role` field on the Django admin and `User` model:
+
+- Admin UI: update the **Role** dropdown when editing a user.
+- Shell example:
+
+```python
+from django.contrib.auth import get_user_model
+User = get_user_model()
+
+User.objects.filter(username="alice").update(role=User.Role.ADMIN)
+```
+
+Newly created users default to `provider`. A data migration upgrades existing superusers to `admin` automatically.
+
+## Enforcement Helpers
+
+- `apps.api.permissions.RoleRequired` checks the authenticated user's `role` against the target view's `required_roles` attribute (admins always pass).
+- `apps.api.permissions.require_roles(*roles)` decorator attaches metadata for function-based views (e.g., `@require_roles(User.Role.ADMIN)` on `/api/v1/stats/`).
+- For DRF viewsets, set `permission_classes = [IsAuthenticated, RoleRequired]` and define `required_roles`.
+
+## Testing
+
+Automated coverage lives in `apps/api/tests/test_rbac.py`:
+- Confirms patients receive 403s on staff endpoints.
+- Blocks providers from admin-only metrics.
+- Allows admins to reach restricted APIs.
+- Exercises the permission utility directly for provider access.
+
+Run the RBAC suite with:
+
+```bash
+DJANGO_SETTINGS_MODULE=config.settings.development python3 manage.py test apps.api.tests.test_rbac
+```
+
+## Extending RBAC
+
+When introducing new endpoints:
+1. Decide which personas should access the route.
+2. Add `required_roles` and include `RoleRequired`.
+3. Update this matrix if the endpoint is public or custom.
+4. Add tests covering both successful and forbidden flows.
+
+For finer-grained object-level rules (e.g., patient-specific record access), extend the permissions module with object checks once domain models solidify.
+


### PR DESCRIPTION
## 📌 Related Issue
Closes #7

## 📋 Summary
This PR implements a fully functional Appointment Scheduling API for 
OpenCare-Africa. Patients can now book, reschedule, and cancel 
appointments with health workers. The system enforces availability 
checks, prevents double-booking, and triggers Celery-based reminder 
notifications. All appointment actions are tracked in the AuditTrail.

## 🔧 Changes Made

### New Files
- `apps/patients/models.py` — Appointment model with status transitions
- `apps/api/serializers/appointment_serializer.py` — Request/response serializers
- `apps/api/views/appointment_views.py` — Appointment viewsets
- `apps/api/tests/test_appointments.py` — Unit and integration tests
- `config/tasks/appointment_reminders.py` — Celery reminder task

### Modified Files
- `apps/api/urls.py` — registered `/api/v1/appointments/` routes
- `config/urls.py` — included appointment URLs
- `config/celery.py` — registered reminder task
- `apps/core/models.py` — extended AuditTrail for appointments
- `docs/appointments.md` — updated with final API usage and safeguards

## 📅 Appointment Status Flow
```
pending → confirmed → completed
                   ↘ cancelled
```

## 🔐 Role Permission Table

| Action                  | Patient | Health Worker | Admin |
|-------------------------|---------|---------------|-------|
| Book appointment        | ✅      | ❌            | ✅    |
| Cancel appointment      | ✅      | ✅            | ✅    |
| Accept/Reject           | ❌      | ✅            | ✅    |
| View all appointments   | ❌      | ✅            | ✅    |
| View own appointments   | ✅      | ✅            | ✅    |

## 🧪 How to Test

1. Apply the migration:
```bash
docker-compose exec web python manage.py migrate
# OR locally:
python manage.py migrate
```

2. Run the test suite:
```bash
# Run all tests
python manage.py test apps.patients
python manage.py test apps.api

# Run with coverage
coverage run --source='.' manage.py test
coverage report
```

3. Test via Swagger UI:
```bash
docker-compose up -d
# Visit http://localhost:8000/api/docs/
# Navigate to /api/v1/appointments/
```

4. Test key scenarios manually:
```bash
# Book an appointment
POST /api/v1/appointments/

# Reschedule
PATCH /api/v1/appointments/{id}/

# Cancel
DELETE /api/v1/appointments/{id}/

# Check double-booking (should return 409)
POST /api/v1/appointments/ # same worker, same time slot
```

## ✅ Checklist

- [ ] Appointment model created with correct status transitions
- [ ] Double-booking prevention returns `409 Conflict`
- [ ] Health worker availability validated via `WorkSchedule`
- [ ] Celery reminder task registered and tested
- [ ] All actions logged in `AuditTrail`
- [ ] API documented in Swagger at `/api/docs/`
- [ ] `docs/appointments.md` updated
- [ ] Tests written and passing
- [ ] No breaking changes to existing endpoints
- [ ] Follows PEP 8 style guidelines