### PR TITLE
Add SECURITY.md, healthcare issue templates, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api_bug.md
+++ b/.github/ISSUE_TEMPLATE/api_bug.md
@@ -1,0 +1,38 @@
+---
+name: API bug
+about: Report a reproducible API or backend behavior issue
+title: "fix: "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+Describe the issue and who is affected.
+
+## Endpoint or Module
+
+Example: `GET /api/v1/patients/`, appointments, audit logging, RBAC.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What should happen?
+
+## Actual Behavior
+
+What happens instead?
+
+## Data Safety Check
+
+- [ ] I removed real patient, staff, facility, token, and credential data.
+- [ ] I used synthetic examples or redacted logs.
+
+## Verification Notes
+
+List test commands, logs, or observations.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,25 @@
+---
+name: Documentation improvement
+about: Improve setup, API, operations, or contributor documentation
+title: "docs: "
+labels: documentation
+assignees: ""
+---
+
+## Documentation Area
+
+Which file, endpoint guide, or workflow needs attention?
+
+## Problem
+
+What is missing, outdated, unsafe, or hard to follow?
+
+## Proposed Change
+
+Describe the update that would resolve the issue.
+
+## Acceptance Criteria
+
+- [ ] The documentation matches the current codebase.
+- [ ] Commands, URLs, and file paths are verified where possible.
+- [ ] Sensitive healthcare data guidance is included when relevant.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+- 
+
+## Linked Issue
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] Feature enhancement
+- [ ] Documentation update
+- [ ] UI/UX improvement
+- [ ] Governance or sustainability improvement
+
+## Healthcare Data Safety
+
+- [ ] No real patient, staff, facility, token, or credential data is included.
+- [ ] API errors and logs remain sanitized.
+- [ ] Not applicable for this change.
+
+## Verification
+
+- [ ] `python manage.py test`
+- [ ] Targeted tests:
+- [ ] Documentation-only change; no runtime tests needed
+
+## Notes for Reviewers
+
+Add migration, deployment, compatibility, or follow-up notes here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+OpenCare-Core handles healthcare workflows, so security reports should be
+treated with care even when the repository is still under active development.
+
+## Reporting a Vulnerability
+
+Do not open a public issue for suspected vulnerabilities, exposed credentials,
+or patient-identifiable data. Instead, contact the maintainers privately through
+the repository owner or the communication channel listed by the BOS-COM project.
+
+Please include:
+
+- A clear description of the vulnerability
+- Steps to reproduce the issue
+- Affected endpoints, models, settings, or deployment modes
+- Any logs or screenshots with secrets and patient data removed
+- Suggested mitigation, if known
+
+## Handling Sensitive Data
+
+- Do not commit real patient, staff, facility, credential, or token data.
+- Use synthetic test fixtures for examples and automated tests.
+- Redact request bodies, headers, cookies, and environment values before sharing
+  logs in issues or pull requests.
+- Keep error responses sanitized; see
+  [`docs/error-handling.md`](docs/error-handling.md).
+
+## Maintainer Triage
+
+Maintainers should acknowledge private vulnerability reports, reproduce the
+issue in a safe environment, prepare a focused fix, and publish remediation notes
+after a patch is available.


### PR DESCRIPTION
 What changed
- Added SECURITY.md with vulnerability reporting process
- Added issue templates for healthcare and API concerns
- Added PR template with healthcare data safety checklist

Why
The repository handles healthcare data but had no security policy 
or contribution governance files, creating risk and inconsistency 
in contributions.

Closes #88