### PR TITLE
docs: add security policy and API testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ This is the **recommended** way to run OpenCare-Africa as it ensures consistency
 
 - Start the stack via Docker or local development, then browse to http://localhost:8000/api/docs/ for interactive OpenAPI documentation.
 - Review sanitized response expectations and logging rules in [`docs/error-handling.md`](docs/error-handling.md) before exposing new endpoints.
-- Extend automated tests to cover both happy-path and error scenarios when updating API behavior; see the error-handling guide for recommendations.
+- Extend automated tests to cover both happy-path and error scenarios when updating API behavior; see [`docs/api-testing.md`](docs/api-testing.md) for API testing guidance.
+- Review [`SECURITY.md`](SECURITY.md) before reporting vulnerabilities or changing authentication, authorization, or sensitive patient-data workflows.
 
 ### 🐳 Docker Services Overview
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+OpenCare-Core handles healthcare workflows and may process sensitive operational
+or patient-related information. Please report security concerns responsibly so
+maintainers can investigate before details are shared publicly.
+
+## Supported Versions
+
+The `main` branch is the active development line and receives security fixes.
+If release branches are introduced later, this section should be updated with a
+version support table.
+
+## Reporting a Vulnerability
+
+Do not open a public GitHub issue for a suspected vulnerability.
+
+Instead, contact the maintainers through the project support channel listed in
+the README or use a private disclosure method provided by the repository owners.
+Include as much detail as possible:
+
+- Affected endpoint, module, or configuration.
+- Steps to reproduce.
+- Expected and actual behavior.
+- Potential impact.
+- Suggested mitigation, if known.
+
+## Handling Expectations
+
+Maintainers should acknowledge reports, assess severity, prepare a fix, and
+publish remediation notes once users have a safe upgrade path.
+
+## Security Review Areas
+
+Contributors should pay special attention to:
+
+- Authentication and authorization checks.
+- Patient data access controls.
+- Input validation and file uploads.
+- Audit logging for sensitive data changes.
+- Error responses that might expose private data.
+- Environment variables and secret handling.

--- a/docs/api-testing.md
+++ b/docs/api-testing.md
@@ -1,0 +1,54 @@
+# API Testing Guide
+
+This guide describes how contributors should test OpenCare-Core API changes
+before opening a pull request.
+
+## Test Scope
+
+API changes should include tests for:
+
+- Successful requests with valid input.
+- Validation failures for missing or malformed input.
+- Permission failures for unauthorized or underprivileged users.
+- Error responses that should be sanitized.
+- Pagination, filtering, and ordering where supported.
+
+## Running Tests
+
+Install development dependencies, then run the API test suite:
+
+```bash
+pip install -r requirements-dev.txt
+pytest apps/api/tests
+```
+
+To run a focused test file:
+
+```bash
+pytest apps/api/tests/test_health_records_api.py
+```
+
+## Writing API Tests
+
+When adding or updating endpoints:
+
+1. Create test data with factories, fixtures, or explicit model setup.
+2. Authenticate as the minimum role needed for the request.
+3. Assert the HTTP status code.
+4. Assert the response body shape and important fields.
+5. Add negative tests for authorization and validation behavior.
+
+## Error Handling Checks
+
+API tests should confirm that client-facing errors are useful without exposing
+private implementation details. For behavior expectations, review
+[`docs/error-handling.md`](error-handling.md).
+
+## Pull Request Checklist
+
+Before submitting an API pull request:
+
+- Run the relevant API tests.
+- Add or update tests for changed behavior.
+- Confirm API documentation or serializers match the response.
+- Note any tests that could not be run and why.


### PR DESCRIPTION
## Summary
- Add SECURITY.md with responsible disclosure guidance for healthcare-related vulnerabilities.
- Add docs/api-testing.md with API testing scope, commands, writing guidance, and PR checklist.
- Link the new security and API testing docs from the README.

## Issues
Closes #54
Closes #64

## Testing
- Documentation-only change; no runtime tests required.